### PR TITLE
Allow to work on non-default XML

### DIFF
--- a/utils/export.py
+++ b/utils/export.py
@@ -33,9 +33,12 @@ def repl(match, playlist):
 
 if __name__ == "__main__":
 
-    home = os.path.expanduser("~")
-    folder = os.path.join(home, "Music/iTunes")
-    iTunesLibraryFile = os.path.join(folder, "iTunes Music Library.xml")
+    if len(sys.argv)>1:
+        iTunesLibraryFile = sys.argv[1];
+    else:
+        home = os.path.expanduser("~")
+        folder = os.path.join(home, "Music/iTunes")
+        iTunesLibraryFile = os.path.join(folder, "iTunes Music Library.xml")
 
     print("Reading %s . . . " % iTunesLibraryFile)
     with open(iTunesLibraryFile, "rb") as fs:


### PR DESCRIPTION
Add the possibility to work with an iTunes/Music.app XML file in any path.
If there is an argument, it's taken to be the path to the XML file.
If not, use the default path.